### PR TITLE
fix traefik label collision and update dashboard port to 9080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,5 @@
 version: "3.9"
 services:
-  web:
-    build: .
-    links:
-      - "db:database"
   db:
     image: postgres
     volumes:
@@ -20,9 +16,9 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.protocol=http"
-      - "traefik.http.routers.authority-router.rule=Host(`myapp.idme.test`)"
-      - "traefik.http.routers.authority-router.entrypoints=web"
-      - "traefik.http.services.authority-service.loadbalancer.server.port=3000"
+      - "traefik.http.routers.myapp-router.rule=Host(`myapp.idme.test`)"
+      - "traefik.http.routers.myapp-router.entrypoints=web"
+      - "traefik.http.services.myapp-service.loadbalancer.server.port=3000"
     depends_on:
       - db
   keycloak.idme.test:
@@ -35,9 +31,9 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.protocol=http"
-      - "traefik.http.routers.authority-router.rule=Host(`keycloak.idme.test`)"
-      - "traefik.http.routers.authority-router.entrypoints=web"
-      - "traefik.http.services.authority-service.loadbalancer.server.port=8080"
+      - "traefik.http.routers.keycloak-router.rule=Host(`keycloak.idme.test`)"
+      - "traefik.http.routers.keycloak-router.entrypoints=web"
+      - "traefik.http.services.keycloak-service.loadbalancer.server.port=8080"
   traefik:
     image: traefik:v2.2.6
     command:
@@ -51,7 +47,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      # - "8080:8080"
+      - "9080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:


### PR DESCRIPTION

- fix traefik label collision
- update traefik dashboard port to 9080
- remove unused app service